### PR TITLE
Add Tests for Redux Slices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-router": "^6.15.0",
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
+        "redux-thunk": "^2.4.2",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
       },
@@ -36,6 +37,7 @@
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "redux-mock-store": "^1.5.4",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^21.0.0",
         "stylelint-csstree-validator": "^1.9.0",
@@ -14510,6 +14512,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -18402,6 +18410,15 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/redux-thunk": {
@@ -32442,6 +32459,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -35090,6 +35113,15 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-router": "^6.15.0",
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
+    "redux-thunk": "^2.4.2",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },
@@ -55,6 +56,7 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "redux-mock-store": "^1.5.4",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^21.0.0",
     "stylelint-csstree-validator": "^1.9.0",

--- a/src/components/AirPollutionDetails.js
+++ b/src/components/AirPollutionDetails.js
@@ -3,7 +3,7 @@ import './AirPollutionDetails.css';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router';
 import { BsArrowLeftCircle } from 'react-icons/bs';
-import { fetchAirPollution } from '../redux/airPollution/airPollutionSlice';
+import fetchAirPollution from '../redux/airPollution/airPollutionApi';
 
 const AirPollutionDetails = () => {
   const { country, lat, lon } = useParams();

--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { BsArrowLeftCircle, BsArrowRightCircle } from 'react-icons/bs';
-import { fetchCountries } from '../redux/countries/countriesSlice';
+import fetchCountries from '../redux/countries/countriesApi';
 
 const Region = () => {
   const { region } = useParams();

--- a/src/redux/airPollution/airPollutionApi.js
+++ b/src/redux/airPollution/airPollutionApi.js
@@ -1,0 +1,18 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const fetchAirPollution = createAsyncThunk(
+  'airPollution/fetchAirPollution',
+  async ({ lat, lon }) => {
+    const response = await fetch(
+      `https://api.openweathermap.org/data/2.5/air_pollution?lat=${lat}&lon=${lon}&appid=1d1d9e533d0b8b9f372b4f4b9a24b5ac`,
+    );
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+    const data = await response.json();
+
+    return data;
+  },
+);
+
+export default fetchAirPollution;

--- a/src/redux/airPollution/airPollutionSlice.js
+++ b/src/redux/airPollution/airPollutionSlice.js
@@ -1,19 +1,5 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-
-export const fetchAirPollution = createAsyncThunk(
-  'airPollution/fetchAirPollution',
-  async ({ lat, lon }) => {
-    const response = await fetch(
-      `https://api.openweathermap.org/data/2.5/air_pollution?lat=${lat}&lon=${lon}&appid=1d1d9e533d0b8b9f372b4f4b9a24b5ac`,
-    );
-    if (!response.ok) {
-      throw new Error('Request failed');
-    }
-    const data = await response.json();
-
-    return data;
-  },
-);
+import { createSlice } from '@reduxjs/toolkit';
+import fetchAirPollution from './airPollutionApi';
 
 const initialState = {
   data: null,

--- a/src/redux/airPollution/airPollutionSlice.test.js
+++ b/src/redux/airPollution/airPollutionSlice.test.js
@@ -1,0 +1,34 @@
+import airPollutionReducer from './airPollutionSlice';
+
+describe('Redux Slice Tests', () => {
+  it('should handle fetchAirPollution.pending', () => {
+    const initialState = { data: null, loading: false, error: null };
+    const action = { type: 'airPollution/fetchAirPollution/pending' };
+    const nextState = airPollutionReducer(initialState, action);
+    expect(nextState.loading).toBe(true);
+  });
+
+  it('should handle fetchAirPollution.fulfilled', () => {
+    const initialState = { data: null, loading: true, error: null };
+    const action = {
+      type: 'airPollution/fetchAirPollution/fulfilled',
+      payload: { someData: 'value' },
+    };
+    const nextState = airPollutionReducer(initialState, action);
+    expect(nextState.loading).toBe(false);
+    expect(nextState.data).toEqual(action.payload);
+    expect(nextState.error).toBeNull();
+  });
+
+  it('should handle fetchAirPollution.rejected', () => {
+    const initialState = { data: null, loading: true, error: null };
+    const action = {
+      type: 'airPollution/fetchAirPollution/rejected',
+      error: { message: 'Error message' },
+    };
+    const nextState = airPollutionReducer(initialState, action);
+    expect(nextState.loading).toBe(false);
+    expect(nextState.data).toBeNull();
+    expect(nextState.error).toBe(action.error.message);
+  });
+});

--- a/src/redux/countries/countriesApi.js
+++ b/src/redux/countries/countriesApi.js
@@ -1,0 +1,19 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const fetchCountries = createAsyncThunk(
+  'countries/fetchCountries',
+  async (region) => {
+    const response = await fetch(
+      `https://restcountries.com/v3.1/region/${region}?fields=name,latlng,area,flags`,
+    );
+
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+
+    const data = await response.json();
+    return data;
+  },
+);
+
+export default fetchCountries;

--- a/src/redux/countries/countriesSlice.js
+++ b/src/redux/countries/countriesSlice.js
@@ -1,20 +1,5 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-
-export const fetchCountries = createAsyncThunk(
-  'countries/fetchCountries',
-  async (region) => {
-    const response = await fetch(
-      `https://restcountries.com/v3.1/region/${region}?fields=name,latlng,area,flags`,
-    );
-
-    if (!response.ok) {
-      throw new Error('Request failed');
-    }
-
-    const data = await response.json();
-    return data;
-  },
-);
+import { createSlice } from '@reduxjs/toolkit';
+import fetchCountries from './countriesApi';
 
 const initialState = {
   data: [],

--- a/src/redux/countries/countriesSlice.test.js
+++ b/src/redux/countries/countriesSlice.test.js
@@ -1,0 +1,34 @@
+import countriesReducer from './countriesSlice';
+
+describe('Countries Slice Tests', () => {
+  it('should handle fetchCountries.pending', () => {
+    const initialState = { data: [], loading: false, error: null };
+    const action = { type: 'countries/fetchCountries/pending' };
+    const nextState = countriesReducer(initialState, action);
+    expect(nextState.loading).toBe(true);
+  });
+
+  it('should handle fetchCountries.fulfilled', () => {
+    const initialState = { data: [], loading: true, error: null };
+    const action = {
+      type: 'countries/fetchCountries/fulfilled',
+      payload: [{ id: 1, name: 'Country 1' }],
+    };
+    const nextState = countriesReducer(initialState, action);
+    expect(nextState.loading).toBe(false);
+    expect(nextState.data).toEqual(action.payload);
+    expect(nextState.error).toBeNull();
+  });
+
+  it('should handle fetchCountries.rejected', () => {
+    const initialState = { data: [], loading: true, error: null };
+    const action = {
+      type: 'countries/fetchCountries/rejected',
+      error: { message: 'Error message' },
+    };
+    const nextState = countriesReducer(initialState, action);
+    expect(nextState.loading).toBe(false);
+    expect(nextState.data).toEqual([]);
+    expect(nextState.error).toBe(action.error.message);
+  });
+});


### PR DESCRIPTION
This pull request adds tests for the Redux slices responsible for handling asynchronous actions `fetchCountries` and `fetchAirPollution`. The tests cover the handling of pending, fulfilled, and rejected actions in both slices, ensuring the proper functionality of the Redux logic.

Changes made in this pull request:
- Added test cases for `fetchCountries` actions in the `countries` slice.
- Added test cases for `fetchAirPollution` actions in the `airPollution` slice.

These tests help maintain the reliability and correctness of the Redux state management in our application.

